### PR TITLE
Add environment-based Supabase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# FODEXA
+
+Este proyecto utiliza Supabase para almacenar datos. Antes de ejecutar la aplicación debes definir las siguientes variables de entorno para indicar tu instancia de Supabase:
+
+```bash
+export SUPABASE_URL="https://tu-proyecto.supabase.co"
+export SUPABASE_KEY="<tu-clave>"
+```
+
+El archivo `config.js` lee estas variables y `services/supabase.js` las utiliza para inicializar el cliente de Supabase.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+// config.js
+// Leer variables de entorno para Supabase
+const supabaseUrl = (typeof process !== 'undefined' && process.env && process.env.SUPABASE_URL) ? process.env.SUPABASE_URL : '';
+const supabaseKey = (typeof process !== 'undefined' && process.env && process.env.SUPABASE_KEY) ? process.env.SUPABASE_KEY : '';
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { supabaseUrl, supabaseKey };
+} else {
+  window.supabaseUrl = supabaseUrl;
+  window.supabaseKey = supabaseKey;
+}

--- a/services/supabase.js
+++ b/services/supabase.js
@@ -3,9 +3,15 @@
 // <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
 
 // Conexión a Supabase para FODEXA (sin import/export, compatible con scripts por <script> tag)
-// NOTA: Reemplaza los valores por los de tu proyecto real
-const supabaseUrl = 'https://lryhbyltkdvijkvpvuch.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxyeWhieWx0a2R2aWprdnB2dWNoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI1MDczNDgsImV4cCI6MjA2ODA4MzM0OH0.onRaOZnOIaiZqMjF9yMsWCu2kOP2JlCr-Bw3lFVxrhQ';
+// Obtiene las credenciales desde config.js
+let config;
+if (typeof module !== 'undefined' && module.exports) {
+    config = require('../config.js');
+} else {
+    config = { supabaseUrl: window.supabaseUrl, supabaseKey: window.supabaseKey };
+}
+
+const { supabaseUrl, supabaseKey } = config;
 
 // Carga el cliente de Supabase desde CDN si no está presente
 if (typeof window.supabase === 'undefined') {


### PR DESCRIPTION
## Summary
- add `config.js` to read `SUPABASE_URL` and `SUPABASE_KEY` from the environment
- use config values in `services/supabase.js`
- document environment variables in a new `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880123492748323aefc6caf38546989